### PR TITLE
Add GNOME 3.30 support

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -157,7 +157,14 @@ function createTray() {
 	sysTray = new Shell.TrayManager();
 	sysTray.connect('tray-icon-added', onTrayIconAdded);
 	sysTray.connect('tray-icon-removed', onTrayIconRemoved);
-	sysTray.manage_screen(global.screen, Main.panel.actor);
+	try {
+		// GNOME 3.28
+		sysTray.manage_screen(global.screen, Main.panel.actor);
+	}
+	catch (err) {
+		// GNOME 3.30+
+		sysTray.manage_screen(Main.panel.actor);
+	}
 }
 
 function destroyTray() {


### PR DESCRIPTION
GNOME 3.30 takes only one argument to `sysTray.manage_screen`. The change was suggested by user dwALX on https://extensions.gnome.org/extension/495/topicons/ (click "Show more reviews" to see the comment). I don't know what's the best way to detect the version of GNOME Shell, so I used try-catch.

I installed the original topIcons extension and replaced the files with the ones from this repository with my patch. It's working now, pidgin shows its icon and doesn't exit when I close it.